### PR TITLE
Include stderr in the exception message

### DIFF
--- a/lib/babl.rb
+++ b/lib/babl.rb
@@ -4,6 +4,7 @@ require 'base64'
 
 module Babl
   class UnknownModuleError < StandardError; end
+
   class ModuleError < StandardError
     attr_reader :stdout, :stderr, :exitcode
 
@@ -11,6 +12,10 @@ module Babl
       @stdout = opts[:stdout]
       @stderr = opts[:stderr]
       @exitcode = opts[:exitcode]
+    end
+
+    def to_s
+      "Module execution failed with exitcode #{exitcode}. Stderr:\n#{stderr}"
     end
   end
 
@@ -56,7 +61,7 @@ module Babl
     exitcode = res['Exitcode']
     if exitcode != 0
       stderr = Base64.decode64(res["Stderr"]).strip
-      raise ModuleError.new(stdout: stdout, stderr: stderr, exitcode: exitcode), "Module execution failed with exitcode #{exitcode}"
+      raise ModuleError.new(stdout: stdout, stderr: stderr, exitcode: exitcode)
     end
     stdout
   end

--- a/spec/babl_spec.rb
+++ b/spec/babl_spec.rb
@@ -23,6 +23,7 @@ describe Babl do
       expect(e.stdout).to eq "this goes to stdout"
       expect(e.stderr).to eq "this goes to stderr\nsome more errors"
       expect(e.exitcode).to be 42
+      expect(e.message).to include "Stderr:\nthis goes to stderr\nsome more errors"
     end
   end
 


### PR DESCRIPTION
In this PR I put `stderr` into `ModuleError#message`. Having it there makes it easier to say why the module failed to execute.

That's one way to show the stderr on services like bugsnag. In this case there's also [another way descirbed here](https://github.com/bugsnag/bugsnag-ruby/blob/master/docs/Notification%20Options.md) but it'd create somehow unwanted dependency issues, I feel.
